### PR TITLE
Added cmd-E shortcut (search for the selected text)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The list above is not exhaustive, but you can learn additional ones via the **[k
 
 **⌘F** *Find*: Open a Find window, or find items in a document.  
 **⌘G** *Find Again*: Find the next occurrence of the item previously found. **⌘⇧G** for previous.
+**⌘E** *Find Selection*: Search for the selected text. Then use **⌘G** and **⌘⇧G** for navigation.
 
 **⌘Space** *Spotlight*: Show or hide the Spotlight search field.  
 **⌥Space** Show Finder search window.


### PR DESCRIPTION
I'm using this more often than cmd-F. 

If you want to search for a word that you see in the text, (once selected) instead of cmd-C, cmd-F, cmd-V, you can just do cmd-E. And then use cmd-G and cmd-shift-G.
